### PR TITLE
Update wxwidgets.props to work with VS 2022

### DIFF
--- a/3.1.5/wxwidgets.props
+++ b/3.1.5/wxwidgets.props
@@ -7,6 +7,10 @@
     tag to it.
   -->
 <Project ToolsVersion="4.0" InitialTargets="CheckWXLibs" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_PropertySheetDisplayName>wxWidgets</_PropertySheetDisplayName>
+  </PropertyGroup>
+
   <ImportGroup Label="PropertySheets">
     <Import Project="build/msw/wx_setup.props" />
     <Import Project="build/msw/wx_local.props" Condition="exists('build/msw/wx_local.props')" />
@@ -21,7 +25,7 @@
       - Version-specific prefix of the form "vcNNN", which is used in some other
         projects.
       - Version-specific but ABI-compatible prefix which differs from the
-        previous value in that it's the same "vc14x" for MSVS 2015/2017/2019
+        previous value in that it's the same "vc14x" for MSVS 2015/2017/2019/2022
         which are ABI-compatible with each other. This is used by official wx
         binaries, so we want to check this one too.
       -->
@@ -31,6 +35,7 @@
     <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '14.0'">140</wxToolsetVersion>
     <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '15.0'">141</wxToolsetVersion>
     <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '16.0'">142</wxToolsetVersion>
+    <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '17.0'">143</wxToolsetVersion>
 
     <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '10.0'">100</wxToolsetVerABICompat>
     <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '11.0'">110</wxToolsetVerABICompat>
@@ -38,6 +43,7 @@
     <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '14.0'">14x</wxToolsetVerABICompat>
     <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '15.0'">14x</wxToolsetVerABICompat>
     <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '16.0'">14x</wxToolsetVerABICompat>
+    <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '17.0'">14x</wxToolsetVerABICompat>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
My additions for VS 2022 were approved in wxWidgets repo: https://github.com/wxWidgets/wxWidgets/commit/adef4c27c2c12f9e482eddfa3ef80ab213b72ea4

There's no need to wait for 3.1.6 for this simple change.